### PR TITLE
Update CNN_model.py

### DIFF
--- a/CNN_model.py
+++ b/CNN_model.py
@@ -23,11 +23,6 @@ std_px = train_X.std().astype(np.float32)
 def standardize(x): 
     return (x-mean_px)/std_px
 
-# One hot encoding of label
-from keras.utils.np_utils import to_categorical
-train_y = to_categorical(train_y)
-num_classes = train_y.shape[1]
-
 # Define the model
 seed = 43
 np.random.seed(seed)
@@ -51,7 +46,7 @@ model = Sequential([
     ])
 
 # Compile the model
-model.compile(Adam(), loss='categorical_crossentropy',
+model.compile(Adam(), loss='sparse_categorical_crossentropy',
                   metrics=['accuracy'])
 
 # Run the model


### PR DESCRIPTION
- One hot encoding
- "sparse_categorical_crossentropy" now used as loss function